### PR TITLE
Allow string for ajax data. Allow element for jQuery selector

### DIFF
--- a/jQuery/jQuery.cs
+++ b/jQuery/jQuery.cs
@@ -1042,6 +1042,17 @@ namespace jQueryApi {
         }
 
         /// <summary>
+        /// Wraps a DOM Element in a jQuery object
+        /// </summary>
+        /// <param name="element">The element to wrap.</param>
+        /// <returns>The resulting jQueryObject instance.</returns>
+        [ScriptAlias("$")]
+        public static jQueryObject Select(Element element)
+        {
+            return null;
+        }
+
+        /// <summary>
         /// Finds one or more DOM elements matching a CSS selector and wraps them into a
         /// <see cref="jQueryObject"/> instance.
         /// </summary>

--- a/jQuery/jQueryAjaxOptions.cs
+++ b/jQuery/jQueryAjaxOptions.cs
@@ -101,7 +101,7 @@ namespace jQueryApi {
         /// <summary>
         /// Gets or sets the data to be sent to the server.
         /// </summary>
-        public TypeOption<JsDictionary<string, object>, Array> Data {
+        public TypeOption<JsDictionary<string, object>, Array, string> Data {
             get {
                 return null;
             }


### PR DESCRIPTION
I've added two changes. One to allow string data for ajax calls. Another to allow an Element as a jQuery selector (jQuery wraps the Element with a jQueryObject)
