### PR TITLE
Don't use [ExpandParams] on Deferred.xxxWith()

### DIFF
--- a/jQuery/jQueryDeferred.cs
+++ b/jQuery/jQueryDeferred.cs
@@ -121,7 +121,6 @@ namespace jQueryApi {
         /// <param name="context">The context in which the callback is invoked.</param>
         /// <param name="args">The arguments to pass to the callbacks.</param>
         /// <returns>The current deferred object.</returns>
-        [ExpandParams]
         public jQueryDeferred RejectWith(object context, params object[] args) {
             return null;
         }
@@ -143,7 +142,6 @@ namespace jQueryApi {
         /// <param name="context">The context in which the callback is invoked.</param>
         /// <param name="args">The arguments to pass to the callbacks.</param>
         /// <returns>The current deferred object.</returns>
-        [ExpandParams]
         public jQueryDeferred ResolveWith(object context, params object[] args) {
             return null;
         }
@@ -382,7 +380,6 @@ namespace jQueryApi {
         /// <param name="context">The context in which the callback is invoked.</param>
         /// <param name="args">The arguments to pass to the callbacks.</param>
         /// <returns>The current deferred object.</returns>
-        [ExpandParams]
         public jQueryDeferred<TData> RejectWith(object context, params TData[] args) {
             return null;
         }
@@ -404,7 +401,6 @@ namespace jQueryApi {
         /// <param name="context">The context in which the callback is invoked.</param>
         /// <param name="args">The arguments to pass to the callbacks.</param>
         /// <returns>The current deferred object.</returns>
-        [ExpandParams]
         public jQueryDeferred<TData> ResolveWith(object context, params TData[] args) {
             return null;
         }


### PR DESCRIPTION
On Deferred.resolveWith() and Deferred.rejectWith(), jQuery actually expects an array to be passed as the second argument. 

It's not well documented on their website (it's more apparent in the code) but you can see some evidence:

http://api.jquery.com/deferred.resolve/
http://api.jquery.com/deferred.resolveWith/

Resolve is marked as taking "args" with type "Anything". ResolveWith is marked as taking "args" with type "Array".
